### PR TITLE
fix: resolve 3 failing unit tests

### DIFF
--- a/src/api/__tests__/util.test.ts
+++ b/src/api/__tests__/util.test.ts
@@ -16,7 +16,7 @@ describe('Util tests', () => {
 
   beforeEach(() => {
     mock({ [path.resolve(__dirname, testDbString)]: '' })
-    reset(testDbString)
+    reset(testDbString, workspaceId)
   })
 
   afterEach(() => {

--- a/src/api/util.ts
+++ b/src/api/util.ts
@@ -16,13 +16,20 @@ export function getWorkspace(dbString: string, id: string): Workspace {
 export function createWorkspace(dbString: string): Workspace {
   const workspace: Workspace = {
     id: uuidv4(),
-    title: 'New Workspace',
+    title: '',
     buildShipments: [
       {
         id: uuidv4(),
         buildNumber: '',
         // Initialize the workspace with a single empty build shipment
-        shipments: [],
+        shipments: [
+          {
+            id: uuidv4(),
+            orderNumber: '',
+            description: '',
+            cost: 0,
+          }
+        ],
       },
     ],
   }


### PR DESCRIPTION
- corrected reset value to take in the generated workspaceId as a parameter in test setup
- sets title in createWorkspace to an empty string ot match test expectation
- add default empty shipment object to buildShipments[0].shipements array in createWorkspace 

how to verify:
run `yarn test --watchAll=false` and all 4 tests should pass