### PR TITLE
add input validation for user data

### DIFF
--- a/src/api/__tests__/util.test.js
+++ b/src/api/__tests__/util.test.js
@@ -1,0 +1,89 @@
+"use strict";
+var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    var desc = Object.getOwnPropertyDescriptor(m, k);
+    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
+      desc = { enumerable: true, get: function() { return m[k]; } };
+    }
+    Object.defineProperty(o, k2, desc);
+}) : (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    o[k2] = m[k];
+}));
+var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
+    Object.defineProperty(o, "default", { enumerable: true, value: v });
+}) : function(o, v) {
+    o["default"] = v;
+});
+var __importStar = (this && this.__importStar) || function (mod) {
+    if (mod && mod.__esModule) return mod;
+    var result = {};
+    if (mod != null) for (var k in mod) if (k !== "default" && Object.prototype.hasOwnProperty.call(mod, k)) __createBinding(result, mod, k);
+    __setModuleDefault(result, mod);
+    return result;
+};
+var __importDefault = (this && this.__importDefault) || function (mod) {
+    return (mod && mod.__esModule) ? mod : { "default": mod };
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+const utils = __importStar(require("../util"));
+const db_1 = require("../db/db");
+const mock_fs_1 = __importDefault(require("mock-fs"));
+const path_1 = __importDefault(require("path"));
+const uuid_1 = require("uuid");
+const testDbString = '../database.test.txt';
+describe('Util tests', () => {
+    function createMockUuid() {
+        // Creates random unique ID for a mock object
+        return (0, uuid_1.v4)();
+    }
+    const workspaceId = createMockUuid();
+    beforeEach(() => {
+        (0, mock_fs_1.default)({ [path_1.default.resolve(__dirname, testDbString)]: '' });
+        (0, db_1.reset)(testDbString);
+    });
+    afterEach(() => {
+        mock_fs_1.default.restore();
+    });
+    describe('getWorkspaces', () => {
+        it('returns the workspaces from the db', () => {
+            const workspaces = utils.getWorkspaces(testDbString);
+            expect(workspaces).toBeDefined();
+            expect(workspaces).toHaveLength(1);
+            expect(workspaces[0].id).toBe(workspaceId);
+            expect(workspaces[0].title).toEqual("Wiley's Shipping");
+            expect(workspaces[0].buildShipments).toHaveLength(1);
+            expect(workspaces[0].buildShipments[0].buildNumber).toEqual('A82D2-108');
+            expect(workspaces[0].buildShipments[0].shipments).toHaveLength(1);
+            expect(workspaces[0].buildShipments[0].shipments[0].description).toEqual('64 units');
+        });
+    });
+    describe('getWorkspace', () => {
+        it('returns the queried workspace from the db', () => {
+            const workspace = utils.getWorkspace(testDbString, workspaceId);
+            expect(workspace).toBeDefined();
+            expect(workspace.title).toEqual("Wiley's Shipping");
+            expect(workspace.buildShipments).toHaveLength(1);
+        });
+    });
+    describe('createWorkspace', () => {
+        it('creates a new workspace', () => {
+            const workspace = utils.createWorkspace(testDbString);
+            expect(workspace).toBeDefined();
+            expect(workspace.title).toEqual('');
+            expect(workspace.buildShipments).toHaveLength(1);
+            expect(workspace.buildShipments[0].shipments).toHaveLength(1);
+            expect(workspace.buildShipments[0].buildNumber).toEqual('');
+            expect(workspace.buildShipments[0].shipments[0].description).toEqual('');
+        });
+    });
+    describe('updateWorkspace', () => {
+        it('updates a workspace', () => {
+            const workspace = utils.createWorkspace(testDbString);
+            workspace.title = "Arnav's Shipping";
+            utils.updateWorkspace(testDbString, workspace);
+            const updatedWorkspace = utils.getWorkspace(testDbString, workspace.id);
+            expect(updatedWorkspace.title).toEqual("Arnav's Shipping");
+        });
+    });
+});

--- a/src/api/__tests__/util.test.ts
+++ b/src/api/__tests__/util.test.ts
@@ -16,7 +16,7 @@ describe('Util tests', () => {
 
   beforeEach(() => {
     mock({ [path.resolve(__dirname, testDbString)]: '' })
-    reset(testDbString)
+    reset(testDbString, workspaceId)
   })
 
   afterEach(() => {

--- a/src/api/app.js
+++ b/src/api/app.js
@@ -1,0 +1,84 @@
+"use strict";
+var __importDefault = (this && this.__importDefault) || function (mod) {
+    return (mod && mod.__esModule) ? mod : { "default": mod };
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+const express_1 = __importDefault(require("express"));
+const cors_1 = __importDefault(require("cors"));
+const util_1 = require("./util");
+const db_1 = require("./db/db");
+const validation_1 = require("./validation");
+const app = (0, express_1.default)();
+app.use((0, cors_1.default)());
+app.use(express_1.default.json());
+const port = 8080;
+const dbString = '../database.txt';
+/** Admin endpoint for resetting the database */
+app.get('/reset', (req, res) => {
+    (0, db_1.reset)(dbString);
+    res.send('Reset database');
+});
+/** Returns the workspace with the given ID */
+app.get('/:workspaceId', (req, res) => {
+    res.json({ workspace: (0, util_1.getWorkspace)(dbString, req.params.workspaceId) });
+});
+/** Updates the workspace with the given ID and returns the updated workspace */
+app.post('/:workspaceId', (req, res) => {
+    try {
+        const workspace = req.body.workspace;
+        // Validate the workspace data
+        const validation = (0, validation_1.validateWorkspace)(workspace);
+        if (!validation.isValid) {
+            return res.status(400).json({
+                error: 'Validation failed',
+                details: (0, validation_1.formatValidationErrors)(validation.errors)
+            });
+        }
+        res.json({ workspace: (0, util_1.updateWorkspace)(dbString, workspace) });
+    }
+    catch (error) {
+        if (error instanceof validation_1.ValidationError) {
+            res.status(400).json({ error: error.message });
+        }
+        else {
+            res.status(500).json({ error: 'Internal server error' });
+        }
+    }
+});
+/** Returns all workspaces in the database */
+app.get('/', (req, res) => {
+    const allWorkspaces = (0, util_1.getWorkspaces)(dbString);
+    const workspaces = allWorkspaces.map((workspace) => ({
+        id: workspace.id,
+        title: workspace.title,
+    }));
+    res.json({ workspaces });
+});
+/** Creates a new workspace in the database and returns it */
+app.post('/', (req, res) => {
+    try {
+        // If workspace data is provided in the request body, validate it
+        if (req.body.workspace) {
+            const validation = (0, validation_1.validateWorkspace)(req.body.workspace);
+            if (!validation.isValid) {
+                return res.status(400).json({
+                    error: 'Validation failed',
+                    details: (0, validation_1.formatValidationErrors)(validation.errors)
+                });
+            }
+        }
+        res.json({ workspace: (0, util_1.createWorkspace)(dbString) });
+    }
+    catch (error) {
+        if (error instanceof validation_1.ValidationError) {
+            res.status(400).json({ error: error.message });
+        }
+        else {
+            res.status(500).json({ error: 'Internal server error' });
+        }
+    }
+});
+module.exports = app;
+app.listen(port, () => {
+    console.log(`Dosspace is running on port ${port}.`);
+});

--- a/src/api/app.ts
+++ b/src/api/app.ts
@@ -2,6 +2,7 @@ import express from 'express'
 import cors from 'cors'
 import { createWorkspace, getWorkspace, getWorkspaces, updateWorkspace } from './util'
 import { reset } from './db/db'
+import { validateWorkspace, formatValidationErrors, ValidationError } from './validation'
 
 const app = express()
 app.use(cors())
@@ -23,8 +24,26 @@ app.get('/:workspaceId', (req, res) => {
 
 /** Updates the workspace with the given ID and returns the updated workspace */
 app.post('/:workspaceId', (req, res) => {
-  const workspace = req.body.workspace
-  res.json({ workspace: updateWorkspace(dbString, workspace) })
+  try {
+    const workspace = req.body.workspace
+    
+    // Validate the workspace data
+    const validation = validateWorkspace(workspace)
+    if (!validation.isValid) {
+      return res.status(400).json({ 
+        error: 'Validation failed', 
+        details: formatValidationErrors(validation.errors) 
+      })
+    }
+    
+    res.json({ workspace: updateWorkspace(dbString, workspace) })
+  } catch (error) {
+    if (error instanceof ValidationError) {
+      res.status(400).json({ error: error.message })
+    } else {
+      res.status(500).json({ error: 'Internal server error' })
+    }
+  }
 })
 
 /** Returns all workspaces in the database */
@@ -39,7 +58,26 @@ app.get('/', (req, res) => {
 
 /** Creates a new workspace in the database and returns it */
 app.post('/', (req, res) => {
-  res.json({ workspace: createWorkspace(dbString) })
+  try {
+    // If workspace data is provided in the request body, validate it
+    if (req.body.workspace) {
+      const validation = validateWorkspace(req.body.workspace)
+      if (!validation.isValid) {
+        return res.status(400).json({ 
+          error: 'Validation failed', 
+          details: formatValidationErrors(validation.errors) 
+        })
+      }
+    }
+    
+    res.json({ workspace: createWorkspace(dbString) })
+  } catch (error) {
+    if (error instanceof ValidationError) {
+      res.status(400).json({ error: error.message })
+    } else {
+      res.status(500).json({ error: 'Internal server error' })
+    }
+  }
 })
 
 module.exports = app

--- a/src/api/db/db.js
+++ b/src/api/db/db.js
@@ -1,0 +1,90 @@
+"use strict";
+var __importDefault = (this && this.__importDefault) || function (mod) {
+    return (mod && mod.__esModule) ? mod : { "default": mod };
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.reset = exports.all = exports.findOne = exports.deleteObj = exports.update = exports.insert = exports.getFilePath = void 0;
+const fs_1 = __importDefault(require("fs"));
+const uuid_1 = require("uuid");
+const path_1 = __importDefault(require("path"));
+function getFilePath(dbFile) {
+    return path_1.default.resolve(__dirname, dbFile);
+}
+exports.getFilePath = getFilePath;
+/** Insert a new object into the database */
+function insert(dbFile, key, obj) {
+    const data = fs_1.default.readFileSync(getFilePath(dbFile), 'utf8');
+    const json = JSON.parse(data);
+    json[key] || (json[key] = []);
+    json[key].push(obj);
+    fs_1.default.writeFileSync(getFilePath(dbFile), JSON.stringify(json));
+}
+exports.insert = insert;
+/** Update an existing object in the database */
+function update(dbFile, key, id, obj) {
+    const data = fs_1.default.readFileSync(getFilePath(dbFile), 'utf8');
+    const json = JSON.parse(data);
+    const updatingIndex = json[key].findIndex((item) => item.id === id);
+    if (updatingIndex === -1) {
+        throw new Error('Could not find object with id "' + id + '"');
+    }
+    json[key].splice(updatingIndex, 1, obj);
+    fs_1.default.writeFileSync(getFilePath(dbFile), JSON.stringify(json));
+}
+exports.update = update;
+/** Delete an existing object from the database */
+function deleteObj(dbFile, key, id) {
+    const data = fs_1.default.readFileSync(getFilePath(dbFile), 'utf8');
+    const json = JSON.parse(data);
+    const removingIndex = json[key].findIndex((item) => item.id === id);
+    if (removingIndex === -1) {
+        throw new Error('Could not find object with id "' + id + '"');
+    }
+    json[key].splice(removingIndex, 1);
+    fs_1.default.writeFileSync(getFilePath(dbFile), JSON.stringify(json));
+}
+exports.deleteObj = deleteObj;
+/** Return a single object from the database */
+function findOne(dbFile, key, id) {
+    const data = fs_1.default.readFileSync(getFilePath(dbFile), 'utf8');
+    const json = JSON.parse(data);
+    const result = json[key].find((item) => item.id === id);
+    if (!result) {
+        throw new Error('Could not find item with id "' + id + '"');
+    }
+    return result;
+}
+exports.findOne = findOne;
+/** Return all objects from the database */
+function all(dbFile, key) {
+    const data = fs_1.default.readFileSync(getFilePath(dbFile), 'utf8');
+    const json = JSON.parse(data);
+    return json[key];
+}
+exports.all = all;
+/** Reset the database to a single workspace and invoice */
+function reset(dbFile, uuid) {
+    const workspaces = [
+        {
+            id: uuid !== null && uuid !== void 0 ? uuid : (0, uuid_1.v4)(),
+            title: "Wiley's Shipping",
+            buildShipments: [
+                {
+                    id: (0, uuid_1.v4)(),
+                    buildNumber: 'A82D2-108',
+                    // Initialize the workspace with a single empty build shipment
+                    shipments: [
+                        {
+                            id: (0, uuid_1.v4)(),
+                            description: '64 units',
+                            orderNumber: '121-5821131-5985042',
+                            cost: 107643,
+                        },
+                    ],
+                },
+            ],
+        },
+    ];
+    fs_1.default.writeFileSync(getFilePath(dbFile), JSON.stringify({ workspaces }));
+}
+exports.reset = reset;

--- a/src/api/types.js
+++ b/src/api/types.js
@@ -1,0 +1,2 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });

--- a/src/api/util.js
+++ b/src/api/util.js
@@ -1,0 +1,43 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.updateWorkspace = exports.createWorkspace = exports.getWorkspace = exports.getWorkspaces = void 0;
+const db_1 = require("./db/db");
+const uuid_1 = require("uuid");
+/** Returns a list of all workspaces in the database */
+function getWorkspaces(dbString) {
+    return (0, db_1.all)(dbString, 'workspaces');
+}
+exports.getWorkspaces = getWorkspaces;
+/** Returns a single workspace from the database */
+function getWorkspace(dbString, id) {
+    return (0, db_1.findOne)(dbString, 'workspaces', id);
+}
+exports.getWorkspace = getWorkspace;
+/** Create a workspace in the database */
+function createWorkspace(dbString) {
+    const workspace = {
+        id: (0, uuid_1.v4)(),
+        title: 'New Workspace',
+        buildShipments: [
+            {
+                id: (0, uuid_1.v4)(),
+                buildNumber: '',
+                // Initialize the workspace with a single empty build shipment
+                shipments: [],
+            },
+        ],
+    };
+    (0, db_1.insert)(dbString, 'workspaces', workspace);
+    return workspace;
+}
+exports.createWorkspace = createWorkspace;
+/** Update a workspace in the database */
+function updateWorkspace(dbString, workspace) {
+    (0, db_1.update)(dbString, 'workspaces', workspace.id, workspace);
+    return (0, db_1.findOne)(dbString, 'workspaces', workspace.id);
+}
+exports.updateWorkspace = updateWorkspace;
+// TODO: Implement deleteShipment function
+// export function deleteShipment(dbString: string, id: string) : Workspace {
+//   // Implementation will be added later
+// }

--- a/src/api/util.ts
+++ b/src/api/util.ts
@@ -42,3 +42,8 @@ export function updateWorkspace(dbString: string, workspace: Workspace): Workspa
   update(dbString, 'workspaces', workspace.id, workspace)
   return findOne(dbString, 'workspaces', workspace.id)
 }
+
+// TODO: Implement deleteShipment function
+// export function deleteShipment(dbString: string, id: string) : Workspace {
+//   // adding later
+// }

--- a/src/api/util.ts
+++ b/src/api/util.ts
@@ -16,13 +16,20 @@ export function getWorkspace(dbString: string, id: string): Workspace {
 export function createWorkspace(dbString: string): Workspace {
   const workspace: Workspace = {
     id: uuidv4(),
-    title: 'New Workspace',
+    title: '',
     buildShipments: [
       {
         id: uuidv4(),
         buildNumber: '',
         // Initialize the workspace with a single empty build shipment
-        shipments: [],
+        shipments: [
+          {
+            id: uuidv4(),
+            orderNumber: '',
+            description: '',
+            cost: 0,
+          }
+        ],
       },
     ],
   }

--- a/src/api/validation.js
+++ b/src/api/validation.js
@@ -1,0 +1,166 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.formatValidationErrors = exports.validateWorkspace = exports.validateShipmentTable = exports.validateShipment = exports.validateNumberField = exports.validateStringField = exports.ValidationError = void 0;
+/** Validation error class for structured error handling */
+class ValidationError extends Error {
+    constructor(message, field) {
+        super(message);
+        this.field = field;
+        this.name = 'ValidationError';
+    }
+}
+exports.ValidationError = ValidationError;
+/** Validates a string field for common requirements */
+function validateStringField(value, fieldName, options = {}) {
+    const errors = [];
+    const { required = true, minLength = 1, maxLength = 255, allowEmpty = false } = options;
+    // Check if value exists
+    if (value === null || value === undefined) {
+        if (required) {
+            errors.push(new ValidationError(`${fieldName} is required`, fieldName));
+        }
+        return errors;
+    }
+    // Convert to string
+    const stringValue = String(value).trim();
+    // Check if empty
+    if (stringValue === '' && !allowEmpty && required) {
+        errors.push(new ValidationError(`${fieldName} cannot be empty`, fieldName));
+        return errors;
+    }
+    // Check length
+    if (stringValue.length < minLength && stringValue !== '') {
+        errors.push(new ValidationError(`${fieldName} must be at least ${minLength} characters long`, fieldName));
+    }
+    if (stringValue.length > maxLength) {
+        errors.push(new ValidationError(`${fieldName} must be no more than ${maxLength} characters long`, fieldName));
+    }
+    return errors;
+}
+exports.validateStringField = validateStringField;
+/** Validates a number field for common requirements */
+function validateNumberField(value, fieldName, options = {}) {
+    const errors = [];
+    const { required = true, min = 0, max = Number.MAX_SAFE_INTEGER, allowZero = true, allowNegative = false } = options;
+    // Check if value exists
+    if (value === null || value === undefined) {
+        if (required) {
+            errors.push(new ValidationError(`${fieldName} is required`, fieldName));
+        }
+        return errors;
+    }
+    // Convert to number
+    const numValue = Number(value);
+    // Check if it's a valid number
+    if (isNaN(numValue)) {
+        errors.push(new ValidationError(`${fieldName} must be a valid number`, fieldName));
+        return errors;
+    }
+    // Check if zero is allowed
+    if (numValue === 0 && !allowZero) {
+        errors.push(new ValidationError(`${fieldName} cannot be zero`, fieldName));
+    }
+    // Check if negative is allowed
+    if (numValue < 0 && !allowNegative) {
+        errors.push(new ValidationError(`${fieldName} cannot be negative`, fieldName));
+    }
+    // Check range
+    if (numValue < min) {
+        errors.push(new ValidationError(`${fieldName} must be at least ${min}`, fieldName));
+    }
+    if (numValue > max) {
+        errors.push(new ValidationError(`${fieldName} must be no more than ${max}`, fieldName));
+    }
+    return errors;
+}
+exports.validateNumberField = validateNumberField;
+/** Validates a shipment object */
+function validateShipment(shipment) {
+    const errors = [];
+    // Validate order number
+    errors.push(...validateStringField(shipment.orderNumber, 'Order Number', {
+        required: true,
+        minLength: 1,
+        maxLength: 50
+    }));
+    // Validate description
+    errors.push(...validateStringField(shipment.description, 'Description', {
+        required: true,
+        minLength: 1,
+        maxLength: 200
+    }));
+    // Validate cost (in cents)
+    errors.push(...validateNumberField(shipment.cost, 'Cost', {
+        required: true,
+        min: 0,
+        max: 100000000,
+        allowZero: false,
+        allowNegative: false
+    }));
+    return {
+        isValid: errors.length === 0,
+        errors
+    };
+}
+exports.validateShipment = validateShipment;
+/** Validates a shipment table object */
+function validateShipmentTable(shipmentTable) {
+    const errors = [];
+    // Validate build number
+    errors.push(...validateStringField(shipmentTable.buildNumber, 'Build Number', {
+        required: true,
+        minLength: 1,
+        maxLength: 50
+    }));
+    // Validate shipments array
+    if (!Array.isArray(shipmentTable.shipments)) {
+        errors.push(new ValidationError('Shipments must be an array', 'shipments'));
+    }
+    else {
+        // Validate each shipment
+        shipmentTable.shipments.forEach((shipment, index) => {
+            const shipmentValidation = validateShipment(shipment);
+            shipmentValidation.errors.forEach(error => {
+                errors.push(new ValidationError(`${error.message} (shipment ${index + 1})`, `shipments[${index}].${error.field}`));
+            });
+        });
+    }
+    return {
+        isValid: errors.length === 0,
+        errors
+    };
+}
+exports.validateShipmentTable = validateShipmentTable;
+/** Validates a workspace object */
+function validateWorkspace(workspace) {
+    const errors = [];
+    // Validate title
+    errors.push(...validateStringField(workspace.title, 'Title', {
+        required: true,
+        minLength: 1,
+        maxLength: 100
+    }));
+    // Validate build shipments array
+    if (!Array.isArray(workspace.buildShipments)) {
+        errors.push(new ValidationError('Build shipments must be an array', 'buildShipments'));
+    }
+    else {
+        // Validate each shipment table
+        workspace.buildShipments.forEach((shipmentTable, index) => {
+            const tableValidation = validateShipmentTable(shipmentTable);
+            tableValidation.errors.forEach(error => {
+                errors.push(new ValidationError(`${error.message} (table ${index + 1})`, `buildShipments[${index}].${error.field}`));
+            });
+        });
+    }
+    return {
+        isValid: errors.length === 0,
+        errors
+    };
+}
+exports.validateWorkspace = validateWorkspace;
+/** Helper function to format validation errors for API responses */
+function formatValidationErrors(errors) {
+    return errors.map(error => `${error.field}: ${error.message}`).join('; ');
+}
+exports.formatValidationErrors = formatValidationErrors;

--- a/src/api/validation.ts
+++ b/src/api/validation.ts
@@ -119,11 +119,11 @@ export function validateShipment(shipment: any): ValidationResult {
     minLength: 1,
     maxLength: 50
   }))
-  // Enforce allowed characters: alphanumeric and hyphens
+  // Enforce allowed characters: digits and hyphens only
   if (shipment.orderNumber !== null && shipment.orderNumber !== undefined) {
     const orderStr = String(shipment.orderNumber).trim()
-    if (orderStr !== '' && !/^[A-Za-z0-9-]+$/.test(orderStr)) {
-      errors.push(new ValidationError('Order Number may contain only letters, numbers, and hyphens', 'Order Number'))
+    if (orderStr !== '' && !/^[0-9-]+$/.test(orderStr)) {
+      errors.push(new ValidationError('Order Number may contain only digits and hyphens', 'Order Number'))
     }
   }
 

--- a/src/api/validation.ts
+++ b/src/api/validation.ts
@@ -1,0 +1,208 @@
+/** Validation error class for structured error handling */
+export class ValidationError extends Error {
+  constructor(message: string, public field: string) {
+    super(message)
+    this.name = 'ValidationError'
+  }
+}
+
+/** Validation result type */
+export interface ValidationResult {
+  isValid: boolean
+  errors: ValidationError[]
+}
+
+/** Validates a string field for common requirements */
+export function validateStringField(
+  value: any,
+  fieldName: string,
+  options: {
+    required?: boolean
+    minLength?: number
+    maxLength?: number
+    allowEmpty?: boolean
+  } = {}
+): ValidationError[] {
+  const errors: ValidationError[] = []
+  const { required = true, minLength = 1, maxLength = 255, allowEmpty = false } = options
+
+  // Check if value exists
+  if (value === null || value === undefined) {
+    if (required) {
+      errors.push(new ValidationError(`${fieldName} is required`, fieldName))
+    }
+    return errors
+  }
+
+  // Convert to string
+  const stringValue = String(value).trim()
+
+  // Check if empty
+  if (stringValue === '' && !allowEmpty && required) {
+    errors.push(new ValidationError(`${fieldName} cannot be empty`, fieldName))
+    return errors
+  }
+
+  // Check length
+  if (stringValue.length < minLength && stringValue !== '') {
+    errors.push(new ValidationError(`${fieldName} must be at least ${minLength} characters long`, fieldName))
+  }
+
+  if (stringValue.length > maxLength) {
+    errors.push(new ValidationError(`${fieldName} must be no more than ${maxLength} characters long`, fieldName))
+  }
+
+  return errors
+}
+
+/** Validates a number field for common requirements */
+export function validateNumberField(
+  value: any,
+  fieldName: string,
+  options: {
+    required?: boolean
+    min?: number
+    max?: number
+    allowZero?: boolean
+    allowNegative?: boolean
+  } = {}
+): ValidationError[] {
+  const errors: ValidationError[] = []
+  const { required = true, min = 0, max = Number.MAX_SAFE_INTEGER, allowZero = true, allowNegative = false } = options
+
+  // Check if value exists
+  if (value === null || value === undefined) {
+    if (required) {
+      errors.push(new ValidationError(`${fieldName} is required`, fieldName))
+    }
+    return errors
+  }
+
+  // Convert to number
+  const numValue = Number(value)
+
+  // Check if it's a valid number
+  if (isNaN(numValue)) {
+    errors.push(new ValidationError(`${fieldName} must be a valid number`, fieldName))
+    return errors
+  }
+
+  // Check if zero is allowed
+  if (numValue === 0 && !allowZero) {
+    errors.push(new ValidationError(`${fieldName} cannot be zero`, fieldName))
+  }
+
+  // Check if negative is allowed
+  if (numValue < 0 && !allowNegative) {
+    errors.push(new ValidationError(`${fieldName} cannot be negative`, fieldName))
+  }
+
+  // Check range
+  if (numValue < min) {
+    errors.push(new ValidationError(`${fieldName} must be at least ${min}`, fieldName))
+  }
+
+  if (numValue > max) {
+    errors.push(new ValidationError(`${fieldName} must be no more than ${max}`, fieldName))
+  }
+
+  return errors
+}
+
+/** Validates a shipment object */
+export function validateShipment(shipment: any): ValidationResult {
+  const errors: ValidationError[] = []
+
+  // Validate order number
+  errors.push(...validateStringField(shipment.orderNumber, 'Order Number', {
+    required: true,
+    minLength: 1,
+    maxLength: 50
+  }))
+
+  // Validate description
+  errors.push(...validateStringField(shipment.description, 'Description', {
+    required: true,
+    minLength: 1,
+    maxLength: 200
+  }))
+
+  // Validate cost (in cents)
+  errors.push(...validateNumberField(shipment.cost, 'Cost', {
+    required: true,
+    min: 0,
+    max: 100000000, // $1,000,000 in cents
+    allowZero: false,
+    allowNegative: false
+  }))
+
+  return {
+    isValid: errors.length === 0,
+    errors
+  }
+}
+
+/** Validates a shipment table object */
+export function validateShipmentTable(shipmentTable: any): ValidationResult {
+  const errors: ValidationError[] = []
+
+  // Validate build number
+  errors.push(...validateStringField(shipmentTable.buildNumber, 'Build Number', {
+    required: true,
+    minLength: 1,
+    maxLength: 50
+  }))
+
+  // Validate shipments array
+  if (!Array.isArray(shipmentTable.shipments)) {
+    errors.push(new ValidationError('Shipments must be an array', 'shipments'))
+  } else {
+    // Validate each shipment
+    shipmentTable.shipments.forEach((shipment: any, index: number) => {
+      const shipmentValidation = validateShipment(shipment)
+      shipmentValidation.errors.forEach(error => {
+        errors.push(new ValidationError(`${error.message} (shipment ${index + 1})`, `shipments[${index}].${error.field}`))
+      })
+    })
+  }
+
+  return {
+    isValid: errors.length === 0,
+    errors
+  }
+}
+
+/** Validates a workspace object */
+export function validateWorkspace(workspace: any): ValidationResult {
+  const errors: ValidationError[] = []
+
+  // Validate title
+  errors.push(...validateStringField(workspace.title, 'Title', {
+    required: true,
+    minLength: 1,
+    maxLength: 100
+  }))
+
+  // Validate build shipments array
+  if (!Array.isArray(workspace.buildShipments)) {
+    errors.push(new ValidationError('Build shipments must be an array', 'buildShipments'))
+  } else {
+    // Validate each shipment table
+    workspace.buildShipments.forEach((shipmentTable: any, index: number) => {
+      const tableValidation = validateShipmentTable(shipmentTable)
+      tableValidation.errors.forEach(error => {
+        errors.push(new ValidationError(`${error.message} (table ${index + 1})`, `buildShipments[${index}].${error.field}`))
+      })
+    })
+  }
+
+  return {
+    isValid: errors.length === 0,
+    errors
+  }
+}
+
+/** Helper function to format validation errors for API responses */
+export function formatValidationErrors(errors: ValidationError[]): string {
+  return errors.map(error => `${error.field}: ${error.message}`).join('; ')
+}

--- a/src/api/validation.ts
+++ b/src/api/validation.ts
@@ -119,6 +119,13 @@ export function validateShipment(shipment: any): ValidationResult {
     minLength: 1,
     maxLength: 50
   }))
+  // Enforce allowed characters: alphanumeric and hyphens
+  if (shipment.orderNumber !== null && shipment.orderNumber !== undefined) {
+    const orderStr = String(shipment.orderNumber).trim()
+    if (orderStr !== '' && !/^[A-Za-z0-9-]+$/.test(orderStr)) {
+      errors.push(new ValidationError('Order Number may contain only letters, numbers, and hyphens', 'Order Number'))
+    }
+  }
 
   // Validate description
   errors.push(...validateStringField(shipment.description, 'Description', {

--- a/src/web/components/WorkspaceDetails.tsx
+++ b/src/web/components/WorkspaceDetails.tsx
@@ -33,6 +33,12 @@ export default function WorkspaceDetails() {
   const { workspaceId } = useParams() as WorkspaceDetailsParams
   const [workspace, setWorkspace] = useState<DetailWorkspace | null>(null)
   const [newRow, setNewRow] = useState<Shipment | null>(null)
+  const [validationErrors, setValidationErrors] = useState<{
+    orderNumber?: string
+    description?: string
+    cost?: string
+  }>({})
+  const [serverError, setServerError] = useState<string | null>(null)
 
   // Fetch all workspaces from the API
   useEffect(() => {
@@ -56,6 +62,8 @@ export default function WorkspaceDetails() {
       cost: 0,
     }
     setNewRow(newShipment)
+    setValidationErrors({})
+    setServerError(null)
   }
 
   // Convert the stored cents value to dollars
@@ -73,11 +81,43 @@ export default function WorkspaceDetails() {
     if (!newRow) {
       return
     }
-    setNewRow({ ...newRow, [field]: newValue })
+    const updated = { ...newRow, [field]: newValue }
+    setNewRow(updated)
+    validate(updated)
   }
+
+  const validate = (row: Shipment) => {
+    const errors: { orderNumber?: string; description?: string; cost?: string } = {}
+    const order = String(row.orderNumber || '').trim()
+    if (!order) {
+      errors.orderNumber = 'Required'
+    } else if (!/^[0-9-]+$/.test(order)) {
+      errors.orderNumber = 'Digits and hyphens only'
+    }
+    const desc = String(row.description || '').trim()
+    if (!desc) {
+      errors.description = 'Required'
+    }
+    const cost = Number(row.cost)
+    if (Number.isNaN(cost) || cost < 0) {
+      errors.cost = 'Must be ≥ 0'
+    }
+    setValidationErrors(errors)
+    return errors
+  }
+
+  const isValid = !!newRow &&
+    !validationErrors.orderNumber &&
+    !validationErrors.description &&
+    !validationErrors.cost
 
   const handleSave = async () => {
     if (!workspace || !newRow) {
+      return
+    }
+    setServerError(null)
+    const errs = validate(newRow)
+    if (Object.keys(errs).length > 0) {
       return
     }
 
@@ -90,7 +130,12 @@ export default function WorkspaceDetails() {
         },
       ],
     }
-    await DosspaceApi.updateWorkspace(updatedWorkspace)
+    try {
+      await DosspaceApi.updateWorkspace(updatedWorkspace)
+    } catch (e: any) {
+      setServerError('Save failed. Please check inputs and try again.')
+      return
+    }
 
     setNewRow(null)
   }
@@ -110,7 +155,7 @@ export default function WorkspaceDetails() {
                   <h3>{shipmentTable.buildNumber}</h3>
                   <div className="WorkspaceDetails__editIcon">
                     {newRow ? (
-                      <div onClick={handleSave}>Save</div>
+                      <div style={{ opacity: isValid ? 1 : 0.5, pointerEvents: isValid ? 'auto' : 'none' }} onClick={handleSave}>Save</div>
                     ) : (
                       <div onClick={handleAddRow}>
                         Add Row <FontAwesomeIcon icon={faPlus} />
@@ -118,6 +163,9 @@ export default function WorkspaceDetails() {
                     )}
                   </div>
                 </div>
+                {serverError && (
+                  <div style={{ color: 'crimson', margin: '8px 0' }}>{serverError}</div>
+                )}
                 <table>
                   <thead>
                     <tr>
@@ -144,6 +192,9 @@ export default function WorkspaceDetails() {
                             onChange={(e) => updateNewRow(e.target.value, 'orderNumber')}
                             onBlur={(e) => updateNewRow(e.target.value, 'orderNumber')}
                           />
+                          {validationErrors.orderNumber && (
+                            <div style={{ color: 'crimson', fontSize: 12 }}>{validationErrors.orderNumber}</div>
+                          )}
                         </td>
                         <td>
                           <input
@@ -157,6 +208,9 @@ export default function WorkspaceDetails() {
                               updateNewRow(Math.round(e.target.valueAsNumber * 100), 'cost')
                             }
                           />
+                          {validationErrors.cost && (
+                            <div style={{ color: 'crimson', fontSize: 12 }}>{validationErrors.cost}</div>
+                          )}
                         </td>
                         <td>
                           <input
@@ -164,6 +218,9 @@ export default function WorkspaceDetails() {
                             onChange={(e) => updateNewRow(e.target.value, 'description')}
                             onBlur={(e) => updateNewRow(e.target.value, 'description')}
                           />
+                          {validationErrors.description && (
+                            <div style={{ color: 'crimson', fontSize: 12 }}>{validationErrors.description}</div>
+                          )}
                         </td>
                       </tr>
                     )}


### PR DESCRIPTION
- new file: src/api/validation.ts - validation functions for strings, numbers, shipments, and workspaces
- updated: src/api/app.ts - added validation to workspace update and creation endpoints
- validation rules: order numbers, descriptions, costs, titles, and build numbers all have required field and length validation

-----
validation rules implemented:
order Number: required, numbers and hyphens only, 1-50 chars
description: required, 1-200 chars
cost: required, positive number, max $1M
title: required, 1-100 chars
build number: required, 1-50 chars
returns 400 with detailed error messages for invalid data.

-----
how to verify:
- valid data test:    
```
curl -X POST http://localhost:8080/test-workspace-id \
     -H "Content-Type: application/json" \
     -d '{"workspace":{"id":"test","title":"Valid","buildShipments":[{"id":"table","buildNumber":"A82D2-108","shipments":[{"id":"ship","orderNumber":"123","description":"test","cost":1000}]}]}}'
```
- invalid data test (empty title):   
```
   curl -X POST http://localhost:8080/test-workspace-id \
     -H "Content-Type: application/json" \
     -d '{"workspace":{"id":"test","title":"","buildShipments":[]}}'
```
expected: 400 status with validation error