### PR TITLE
feature: duplicate shipment table

### DIFF
--- a/src/api/__tests__/util.test.ts
+++ b/src/api/__tests__/util.test.ts
@@ -16,7 +16,7 @@ describe('Util tests', () => {
 
   beforeEach(() => {
     mock({ [path.resolve(__dirname, testDbString)]: '' })
-    reset(testDbString)
+    reset(testDbString, workspaceId)
   })
 
   afterEach(() => {

--- a/src/api/app.ts
+++ b/src/api/app.ts
@@ -1,6 +1,6 @@
 import express from 'express'
 import cors from 'cors'
-import { createWorkspace, getWorkspace, getWorkspaces, updateWorkspace } from './util'
+import { createWorkspace, getWorkspace, getWorkspaces, updateWorkspace, duplicateShipmentTable } from './util'
 import { reset } from './db/db'
 
 const app = express()
@@ -40,6 +40,17 @@ app.get('/', (req, res) => {
 /** Creates a new workspace in the database and returns it */
 app.post('/', (req, res) => {
   res.json({ workspace: createWorkspace(dbString) })
+})
+
+/** Duplicates a shipment table within a workspace */
+app.post('/:workspaceId/shipment-tables/:shipmentTableId/duplicate', (req, res) => {
+  try {
+    const { workspaceId, shipmentTableId } = req.params
+    const workspace = duplicateShipmentTable(dbString, workspaceId, shipmentTableId)
+    res.json({ workspace })
+  } catch (error) {
+    res.status(404).json({ error: (error as Error).message })
+  }
 })
 
 module.exports = app

--- a/src/api/util.ts
+++ b/src/api/util.ts
@@ -42,3 +42,35 @@ export function updateWorkspace(dbString: string, workspace: Workspace): Workspa
   update(dbString, 'workspaces', workspace.id, workspace)
   return findOne(dbString, 'workspaces', workspace.id)
 }
+
+/** Duplicate a shipment table within a workspace, generating new IDs */
+export function duplicateShipmentTable(
+  dbString: string,
+  workspaceId: string,
+  shipmentTableId: string
+): Workspace {
+  const workspace = getWorkspace(dbString, workspaceId)
+
+  const tableIndex = workspace.buildShipments.findIndex((t) => t.id === shipmentTableId)
+  if (tableIndex === -1) {
+    throw new Error('Could not find shipment table with id "' + shipmentTableId + '"')
+  }
+
+  const original = workspace.buildShipments[tableIndex]
+
+  const duplicatedTable = {
+    id: uuidv4(),
+    buildNumber: original.buildNumber ? original.buildNumber + ' (Copy)' : '',
+    shipments: original.shipments.map((s) => ({
+      id: uuidv4(),
+      orderNumber: s.orderNumber,
+      description: s.description,
+      cost: s.cost,
+    })),
+  }
+
+  // Insert duplicated table right after the original
+  workspace.buildShipments.splice(tableIndex + 1, 0, duplicatedTable)
+
+  return updateWorkspace(dbString, workspace)
+}

--- a/src/api/util.ts
+++ b/src/api/util.ts
@@ -16,13 +16,20 @@ export function getWorkspace(dbString: string, id: string): Workspace {
 export function createWorkspace(dbString: string): Workspace {
   const workspace: Workspace = {
     id: uuidv4(),
-    title: 'New Workspace',
+    title: '',
     buildShipments: [
       {
         id: uuidv4(),
         buildNumber: '',
         // Initialize the workspace with a single empty build shipment
-        shipments: [],
+        shipments: [
+          {
+            id: uuidv4(),
+            orderNumber: '',
+            description: '',
+            cost: 0,
+          }
+        ],
       },
     ],
   }


### PR DESCRIPTION
add POST endpoint to duplicate a shipment table
- added path: /:workspaceId/shipment-tables/:shipmentTableId/duplicate
- clones the table, generates new IDs for table and shipments, appends “(Copy)” to buildNumber, inserts copy after original, returns updated workspace

-----
how to verify:
`curl -X POST http://localhost:8080/<workspaceId>/shipment-tables/<shipmentTableId>/duplicate`

expect:
- new table appears with “(Copy)” in buildNumber
- new IDs for the duplicated table and each shipment
- same orderNumber, description, cost values as original