### PR TITLE
feature: delete shipment from shipment table

### DIFF
--- a/src/api/__tests__/util.test.ts
+++ b/src/api/__tests__/util.test.ts
@@ -16,7 +16,7 @@ describe('Util tests', () => {
 
   beforeEach(() => {
     mock({ [path.resolve(__dirname, testDbString)]: '' })
-    reset(testDbString)
+    reset(testDbString, workspaceId)
   })
 
   afterEach(() => {

--- a/src/api/app.ts
+++ b/src/api/app.ts
@@ -1,6 +1,6 @@
 import express from 'express'
 import cors from 'cors'
-import { createWorkspace, getWorkspace, getWorkspaces, updateWorkspace } from './util'
+import { createWorkspace, getWorkspace, getWorkspaces, updateWorkspace, deleteShipment } from './util'
 import { reset } from './db/db'
 
 const app = express()
@@ -40,6 +40,17 @@ app.get('/', (req, res) => {
 /** Creates a new workspace in the database and returns it */
 app.post('/', (req, res) => {
   res.json({ workspace: createWorkspace(dbString) })
+})
+
+/** Deletes a shipment from a shipment table within a workspace */
+app.delete('/:workspaceId/shipment-tables/:shipmentTableId/shipments/:shipmentId', (req, res) => {
+  try {
+    const { workspaceId, shipmentTableId, shipmentId } = req.params
+    const workspace = deleteShipment(dbString, workspaceId, shipmentTableId, shipmentId)
+    res.json({ workspace })
+  } catch (err) {
+    res.status(404).json({ error: (err as Error).message })
+  }
 })
 
 module.exports = app

--- a/src/api/util.ts
+++ b/src/api/util.ts
@@ -42,3 +42,27 @@ export function updateWorkspace(dbString: string, workspace: Workspace): Workspa
   update(dbString, 'workspaces', workspace.id, workspace)
   return findOne(dbString, 'workspaces', workspace.id)
 }
+
+/** Delete a shipment from a specific shipment table within a workspace */
+export function deleteShipment(
+  dbString: string,
+  workspaceId: string,
+  shipmentTableId: string,
+  shipmentId: string
+): Workspace {
+  const workspace = getWorkspace(dbString, workspaceId)
+
+  const tableIndex = workspace.buildShipments.findIndex((t) => t.id === shipmentTableId)
+  if (tableIndex === -1) {
+    throw new Error('Could not find shipment table with id "' + shipmentTableId + '"')
+  }
+
+  const shipments = workspace.buildShipments[tableIndex].shipments
+  const shipmentIndex = shipments.findIndex((s) => s.id === shipmentId)
+  if (shipmentIndex === -1) {
+    throw new Error('Could not find shipment with id "' + shipmentId + '"')
+  }
+
+  shipments.splice(shipmentIndex, 1)
+  return updateWorkspace(dbString, workspace)
+}

--- a/src/api/util.ts
+++ b/src/api/util.ts
@@ -16,13 +16,20 @@ export function getWorkspace(dbString: string, id: string): Workspace {
 export function createWorkspace(dbString: string): Workspace {
   const workspace: Workspace = {
     id: uuidv4(),
-    title: 'New Workspace',
+    title: '',
     buildShipments: [
       {
         id: uuidv4(),
         buildNumber: '',
         // Initialize the workspace with a single empty build shipment
-        shipments: [],
+        shipments: [
+          {
+            id: uuidv4(),
+            orderNumber: '',
+            description: '',
+            cost: 0,
+          }
+        ],
       },
     ],
   }


### PR DESCRIPTION
- add API to delete a shipment from a shipment table within a workspace.
- built on top of fix-tests to align with corrected defaults and IDs.
- added deleteShipment function in `util.ts` and a delete api route in `app.ts`

-----
how to verify:
`curl -X DELETE http://localhost:8080/<workspaceId>/shipment-tables/<shipmentTableId>/shipments/<shipmentId>`

expect:
the returned workspace with the shipment removed